### PR TITLE
Log stacktrace if maximum retries are exceeded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,15 @@ python:
 services:
     - rabbitmq
 env:
-    - DJANGO="Django>=1.10,<1.11"
     - DJANGO="Django>=1.11,<1.12"
     - DJANGO="Django>=2.0,<2.1"
+    - DJANGO="Django>=2.1,<2.2"
 matrix:
     exclude:
         - python: "2.7"
           env: DJANGO="Django>=2.0,<2.1"
+        - python: "2.7"
+          env: DJANGO="Django>=2.1,<2.2"
 install:
     - pip install -r requirements.txt -e .
     - pip install $DJANGO

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -3,7 +3,7 @@ coverage
 flake8
 mock
 pika >= 0.10
-pytest >= 3.0.0
+pytest >= 3.6.0
 pytest-django
 sphinx
 sphinx_rtd_theme

--- a/domain_events/transport.py
+++ b/domain_events/transport.py
@@ -126,7 +126,9 @@ def receive_callback(handler, name, retry_exchange, max_retries,
                 _retry_message(error.delay, name, retry_exchange, channel, method, properties, body)
             else:
                 # Reject puts the message into the dead-letter queue if there is one
-                log.warning("Exceeded max retries ({}) for event {}".format(max_retries, event))
+                log.error("Exceeded max retries ({}) for {} event".format(max_retries, event.routing_key),
+                          exc_info=True,
+                          extra=event.event_data)
                 channel.basic_reject(delivery_tag=method.delivery_tag, requeue=False)
         except:  # noqa: E722
             # Note: If we want immediate requeueing, add a `RequeueError` that


### PR DESCRIPTION
Don't hide exceptions if a consumer raises Retry everytime and exceeds
the retry limit for the consumer. Also allow grouping of the log message
in Sentry by not rendering the event ID into the message.